### PR TITLE
Fix wildcard search/replace

### DIFF
--- a/mkvtoolnix_merge_mapper.py
+++ b/mkvtoolnix_merge_mapper.py
@@ -365,7 +365,7 @@ while ep_num < int(end_episode)+1:
                 #replace options data with matched filename
                 options_data_temp[i] = completion_path + v[x+3:]
 
-        if "**" in v:
+        elif "**" in v:
             v = options_data_temp[i]
             #finds index of "**"
             x = v.index("**")


### PR DESCRIPTION
If *** was found in 'v' then 'v' is set to temp output string before wildcard replacement in line 338, then checked against ** in line 368 which means that conditional always passes. You could probably do a more complex change for more robust code, for instance this makes using the two wildcard patterns mutually exclusive; if you wanted to use both at the same time you would probably want to do something like set v at the end on the conditional started on line 330 to the string after all *** wildcard replacement. This is just the quick n dirty solution.