### PR TITLE
Added "additonal fonts" support to FontCollector automation

### DIFF
--- a/mkvconfig.json
+++ b/mkvconfig.json
@@ -13,6 +13,7 @@
 
     "auto_font_mux":"",
     "font_collector_log":"no",
+    "additional_fonts":[],
 
     "titles_in_filename":"",
     "titles_in_mkv":"",

--- a/mkvtoolnix_merge_mapper.py
+++ b/mkvtoolnix_merge_mapper.py
@@ -29,6 +29,7 @@ default_config = {
 
 "auto_font_mux":"",
 "font_collector_log":"no",
+"additional_fonts":[],
 
 "titles_in_filename":"",
 "titles_in_mkv":"",
@@ -72,6 +73,7 @@ mkvtitles_filename = config['mkvtitles_filename']
 
 auto_font_q = config['auto_font_mux']
 font_collector_log = config['font_collector_log']
+additional_fonts = config['additional_fonts']
 
 titles_filename_q = config['titles_in_filename']
 titles_mux_q = config['titles_in_mkv']
@@ -522,7 +524,7 @@ while ep_num < int(end_episode)+1:
 
         #run fontcollector and mux all needed fonts
         if not font_collector_log:
-            with subprocess.Popen(["fontcollector", "-mkv", output_file, "-d", "-mkvpropedit", mkv_propedit_path, "--additional-fonts", temp_dir, "--input"] + fontcollector_args, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True, text=True) as p:
+            with subprocess.Popen(["fontcollector", "-mkv", output_file, "-d", "-mkvpropedit", mkv_propedit_path, "--additional-fonts", temp_dir] + additional_fonts + ["--input"] + fontcollector_args, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True, text=True) as p:
                 for line in p.stderr:
                     if "All fonts found" in line:
                         print(f"{Fore.GREEN}", line, f"{Fore.RESET}", end="")
@@ -535,7 +537,7 @@ while ep_num < int(end_episode)+1:
         #same but with log
         else:
             with open(log_path, "a") as log:
-                with subprocess.Popen(["fontcollector", "-mkv", output_file, "-d", "-mkvpropedit", mkv_propedit_path, "--additional-fonts", temp_dir, "--input"] + fontcollector_args, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True, text=True) as p:
+                with subprocess.Popen(["fontcollector", "-mkv", output_file, "-d", "-mkvpropedit", mkv_propedit_path, "--additional-fonts", temp_dir] + additional_fonts + ["--input"] + fontcollector_args, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True, text=True) as p:
                     for line in p.stderr:
                         log.write(line)
                         if "All fonts found" in line:


### PR DESCRIPTION
I could be missing something, but the Automatic Font muxing currently supported doesn't seem to accomplish much other than removing unused font attachments; it won't be able to find missing fonts and add them in unless they are installed on your computer. This change will allow the user to define additional font folders and pass them along to that same argument to FontCollector, allowing you to mux extra fonts that may be missing from the original files back in.

This is just a change I made for myself so I could more easily batch font fixes for already-muxed files, feel free to discard this if you don't want this change. I set the default to be no folders so operation of this tool should remain exactly the same as it was before unless the user changes 'additional_fonts' in config.